### PR TITLE
Add some components for cdm internal testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # shopping-cart-cdm
+hello

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # shopping-cart-cdm
-hello
+hello hello

--- a/cloud-deploy/targets-yaml-gen.sh
+++ b/cloud-deploy/targets-yaml-gen.sh
@@ -1,0 +1,1 @@
+sed -e "s/\${PROJECT_ID}/$1/g" -e "s/\${REGION}/$2/g" targets.yaml.template > targets.yaml

--- a/cloud-deploy/targets.yaml.template
+++ b/cloud-deploy/targets.yaml.template
@@ -1,0 +1,39 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: deploy.cloud.google.com/v1beta1
+kind: Target
+metadata:
+  name: test
+description: test cluster
+gke:
+  cluster: projects/${PROJECT_ID}/locations/${REGION}/clusters/test
+---
+apiVersion: deploy.cloud.google.com/v1beta1
+kind: Target
+metadata:
+  name: staging
+description: staging cluster
+gke:
+  cluster: projects/${PROJECT_ID}/locations/${REGION}/clusters/staging
+---
+apiVersion: deploy.cloud.google.com/v1beta1
+kind: Target
+metadata:
+  name: prod
+description: prod cluster
+requireApproval: true
+gke:
+  cluster: projects/${PROJECT_ID}/locations/${REGION}/clusters/prod
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,8 @@
 steps:
   - name: gcr.io/cloud-builders/docker
     args: ["build", "-t", "us-central1-docker.pkg.dev/$PROJECT_ID/docker-repo/shopping-cart-cdm:github-${REPO_NAME}.${BRANCH_NAME}.${SHORT_SHA}", "."]
-images: ["us-central1-docker.pkg.dev/$PROJECT_ID/docker-repo/shopping-cart-cdm:github-${REPO_NAME}.${BRANCH_NAME}.${SHORT_SHA}"]
+  - name: gcr.io/cloud-builders/docker
+    args: ["push", "us-central1-docker.pkg.dev/$PROJECT_ID/docker-repo/shopping-cart-cdm:github-${REPO_NAME}.${BRANCH_NAME}.${SHORT_SHA}"]
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    args: ['gcloud', 'beta', 'deploy', 'releases', 'create', 'shopping-cart-$BUILD_ID', '--delivery-pipeline=shopping-cart-cdm', '--region=us-central1', '--images=name=us-central1-docker.pkg.dev/$PROJECT_ID/docker-repo/shopping-cart-cdm:github-${REPO_NAME}.${BRANCH_NAME}.${SHORT_SHA}']
+


### PR DESCRIPTION
Add a config template for targets and a script that generates yaml based on project id and region.
Also let cloud build automatically create release in cloud deploy after a successful build. Any concerns about this?